### PR TITLE
Implement cross-path sect raid mechanics and update TODO documentation

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5,9 +5,8 @@
 ## Next Version
 - Skill sets for alchemy, forging, cooking
 - Add more combat loot
-- Sect phase 2
-  - **To get items from the demonic sect you have to battle them. So if you are a core disciple in your righteous sect you can battle a demonic sect and then get the loot from a loot table up to the core disciple level.**
 
+- Sect phase 3. Relationships
 - All skill expansion with content to level 120
 
 

--- a/src/components/SectWindow/SectWindow.tsx
+++ b/src/components/SectWindow/SectWindow.tsx
@@ -4,6 +4,9 @@ import { setSect } from "../../state/reducers/characterSlice";
 import { RootState } from "../../state/store";
 import { sectsData } from "../../constants/data";
 import SectI from "../../interfaces/SectI";
+import { changeContent } from "../../state/reducers/contentSlice";
+import { ContentArea } from "../../enum/ContentArea";
+import { CombatArea } from "../../enum/CombatArea";
 import "./SectWindow.css";
 
 interface SectWindowProps {
@@ -15,11 +18,35 @@ export const SectWindow: React.FC<SectWindowProps> = ({ sect, onClose }) => {
   const dispatch = useDispatch();
   const path = useSelector((state: RootState) => state.character.path);
   const currentSectId = useSelector((state: RootState) => state.character.currentSectId);
+  const sectRankIndex = useSelector((state: RootState) => state.character.sectRankIndex);
   const isMember = currentSectId === sect.id;
   const pathMatches = path != null && sect.path === path;
   const inAnotherSect = currentSectId != null && currentSectId !== sect.id;
   const currentSect = currentSectId != null ? sectsData.find((s) => s.id === currentSectId) : null;
   const canJoin = pathMatches && !inAnotherSect;
+
+  const isOpposingSect = path != null && sect.path !== path;
+  const isOnOwnPathSect = currentSect != null && currentSect.path === path;
+  const isEligibleRaider = isOnOwnPathSect && isOpposingSect && sectRankIndex > 0;
+
+  const getRaidAreaForSect = (s: SectI): CombatArea | null => {
+    switch (s.id) {
+      case 1:
+        return CombatArea.JADE_MOUNTAIN_RAID;
+      case 2:
+        return CombatArea.VERDANT_VALLEY_RAID;
+      case 3:
+        return CombatArea.AZURE_SKY_RAID;
+      case 4:
+        return CombatArea.CRIMSON_DEMON_RAID;
+      case 5:
+        return CombatArea.SHADOW_SERPENT_RAID;
+      case 6:
+        return CombatArea.BONE_ABYSS_RAID;
+      default:
+        return null;
+    }
+  };
 
   const handleJoin = () => {
     if (canJoin) dispatch(setSect(sect.id));
@@ -27,6 +54,14 @@ export const SectWindow: React.FC<SectWindowProps> = ({ sect, onClose }) => {
 
   const handleLeave = () => {
     dispatch(setSect(null));
+  };
+
+  const handleBattle = () => {
+    if (!isEligibleRaider) return;
+    const raidArea = getRaidAreaForSect(sect);
+    if (!raidArea) return;
+    dispatch(changeContent(`${ContentArea.COMBAT}:${raidArea}`));
+    onClose();
   };
 
   const joinDisabledTitle = !pathMatches
@@ -47,6 +82,11 @@ export const SectWindow: React.FC<SectWindowProps> = ({ sect, onClose }) => {
         <h2 id="sect-window-title" className="sectWindow__title">{sect.name}</h2>
         <p className="sectWindow__path">{sect.path} sect</p>
         <p className="sectWindow__description">{sect.description}</p>
+        {isOpposingSect && (
+          <p className="sectWindow__pathOnly sectWindow__pathOnly--info">
+            You follow the <strong>{path}</strong> path; this is an opposing sect. At higher ranks, you can battle its disciples for their techniques and treasures.
+          </p>
+        )}
         {!pathMatches && !isMember && path != null && (
           <p className="sectWindow__pathOnly">Only cultivators on the {sect.path} path may join this sect.</p>
         )}
@@ -69,6 +109,21 @@ export const SectWindow: React.FC<SectWindowProps> = ({ sect, onClose }) => {
               title={joinDisabledTitle}
             >
               Join sect
+            </button>
+          )}
+          {isOpposingSect && (
+            <button
+              type="button"
+              className="sectWindow__btn sectWindow__btn--join"
+              onClick={handleBattle}
+              disabled={!isEligibleRaider}
+              title={
+                isEligibleRaider
+                  ? "Battle this sect's disciples for loot matching your sect rank."
+                  : "Requires you to be at least an Outer Disciple in a sect on your own path before you can battle this opposing sect."
+              }
+            >
+              Battle this sect
             </button>
           )}
           <button type="button" className="sectWindow__btn sectWindow__btn--close" onClick={onClose}>

--- a/src/constants/areaRealmRequirements.ts
+++ b/src/constants/areaRealmRequirements.ts
@@ -20,6 +20,14 @@ export const AREA_REALM_REQUIREMENTS: Record<string, RealmRequirement> = {
   [CombatArea.SEA]: { realmId: "Mahayana", realmLevel: 1 },
   [CombatArea.STORM]: { realmId: "Tribulation Transcendent", realmLevel: 1 },
   [CombatArea.PALACE]: { realmId: "Immortal", realmLevel: 1 },
+
+  // Sect raid areas – accessible from early sect progression (Outer Disciple / Qi Condensation)
+  [CombatArea.JADE_MOUNTAIN_RAID]: { realmId: "Qi Condensation", realmLevel: 1 },
+  [CombatArea.VERDANT_VALLEY_RAID]: { realmId: "Qi Condensation", realmLevel: 1 },
+  [CombatArea.AZURE_SKY_RAID]: { realmId: "Qi Condensation", realmLevel: 1 },
+  [CombatArea.CRIMSON_DEMON_RAID]: { realmId: "Qi Condensation", realmLevel: 1 },
+  [CombatArea.SHADOW_SERPENT_RAID]: { realmId: "Qi Condensation", realmLevel: 1 },
+  [CombatArea.BONE_ABYSS_RAID]: { realmId: "Qi Condensation", realmLevel: 1 },
 };
 
 export function canEnterArea(

--- a/src/constants/data.ts
+++ b/src/constants/data.ts
@@ -151,6 +151,20 @@ export const sectStoreData: Record<number, SectStoreEntryI[]> = {
   ],
 };
 
+/** Rank-aware sect raid loot helpers. For a given sect id and raider sect rank, return items and weights. */
+export function getSectRaidLootForRank(
+  sectId: number,
+  sectRankIndex: number
+): { items: Item[]; weight: number[] } | null {
+  const entries = sectStoreData[sectId];
+  if (!entries || sectRankIndex <= 0) return null;
+  const eligible = entries.filter((e) => e.requiredRankIndex <= sectRankIndex);
+  if (eligible.length === 0) return null;
+  const items = eligible.map((e) => e.item);
+  const weight = eligible.map(() => 1);
+  return { items, weight };
+}
+
 /** Sects on the world map. 3 Righteous, 3 Demonic. positionX/Y are percentage (0–100) for map pin. */
 export const sectsData: SectI[] = [
   { id: 1, name: "Jade Mountain Sect", description: "A righteous sect known for sword arts and strict discipline.", path: "Righteous", positionX: 23, positionY: 36 },
@@ -309,6 +323,33 @@ export const enemies: EnemyI[] = [
   { id: 53, name: "Golden Seal Arbiter", attack: 56, defense: 45, health: 285, location: CombatArea.PALACE, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Golden Seal Arbiter")}.webp`, loot: { items: [COMBAT_LOOT_QI_PILLS[9]], weight: [1] } },
   { id: 54, name: "Azure Hall Guardian", attack: 55, defense: 44, health: 280, location: CombatArea.PALACE, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Azure Hall Guardian")}.webp`, loot: { items: [COMBAT_LOOT_QI_PILLS[9]], weight: [1] } },
   { id: 55, name: "Celestial Punisher", attack: 58, defense: 47, health: 300, location: CombatArea.PALACE, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Celestial Punisher")}.webp`, loot: { items: [COMBAT_LOOT_QI_PILLS[9], QI_TECHNIQUES[14]], weight: [8, 1] } },
+
+  // Sect raid enemies – cross-path sect battles (loot handled dynamically based on raider rank and sect)
+  // Righteous sects (raided by Demonic-path players)
+  { id: 101, name: "Jade Mountain Outer Disciple", attack: 18, defense: 14, health: 85, location: CombatArea.JADE_MOUNTAIN_RAID, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Jade Mountain Outer Disciple")}.webp`, loot: { items: [], weight: [] } },
+  { id: 102, name: "Jade Mountain Inner Disciple", attack: 24, defense: 18, health: 115, location: CombatArea.JADE_MOUNTAIN_RAID, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Jade Mountain Inner Disciple")}.webp`, loot: { items: [], weight: [] } },
+  { id: 103, name: "Jade Mountain Core Disciple", attack: 30, defense: 22, health: 145, location: CombatArea.JADE_MOUNTAIN_RAID, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Jade Mountain Core Disciple")}.webp`, loot: { items: [], weight: [] } },
+
+  { id: 104, name: "Verdant Valley Outer Disciple", attack: 18, defense: 13, health: 80, location: CombatArea.VERDANT_VALLEY_RAID, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Verdant Valley Outer Disciple")}.webp`, loot: { items: [], weight: [] } },
+  { id: 105, name: "Verdant Valley Inner Disciple", attack: 23, defense: 17, health: 110, location: CombatArea.VERDANT_VALLEY_RAID, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Verdant Valley Inner Disciple")}.webp`, loot: { items: [], weight: [] } },
+  { id: 106, name: "Verdant Valley Core Disciple", attack: 29, defense: 21, health: 140, location: CombatArea.VERDANT_VALLEY_RAID, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Verdant Valley Core Disciple")}.webp`, loot: { items: [], weight: [] } },
+
+  { id: 107, name: "Azure Sky Outer Disciple", attack: 19, defense: 14, health: 88, location: CombatArea.AZURE_SKY_RAID, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Azure Sky Outer Disciple")}.webp`, loot: { items: [], weight: [] } },
+  { id: 108, name: "Azure Sky Inner Disciple", attack: 25, defense: 18, health: 118, location: CombatArea.AZURE_SKY_RAID, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Azure Sky Inner Disciple")}.webp`, loot: { items: [], weight: [] } },
+  { id: 109, name: "Azure Sky Core Disciple", attack: 31, defense: 22, health: 148, location: CombatArea.AZURE_SKY_RAID, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Azure Sky Core Disciple")}.webp`, loot: { items: [], weight: [] } },
+
+  // Demonic sects (raided by Righteous-path players)
+  { id: 110, name: "Crimson Demon Outer Disciple", attack: 20, defense: 13, health: 90, location: CombatArea.CRIMSON_DEMON_RAID, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Crimson Demon Outer Disciple")}.webp`, loot: { items: [], weight: [] } },
+  { id: 111, name: "Crimson Demon Inner Disciple", attack: 26, defense: 17, health: 120, location: CombatArea.CRIMSON_DEMON_RAID, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Crimson Demon Inner Disciple")}.webp`, loot: { items: [], weight: [] } },
+  { id: 112, name: "Crimson Demon Core Disciple", attack: 32, defense: 21, health: 150, location: CombatArea.CRIMSON_DEMON_RAID, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Crimson Demon Core Disciple")}.webp`, loot: { items: [], weight: [] } },
+
+  { id: 113, name: "Shadow Serpent Outer Disciple", attack: 21, defense: 12, health: 88, location: CombatArea.SHADOW_SERPENT_RAID, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Shadow Serpent Outer Disciple")}.webp`, loot: { items: [], weight: [] } },
+  { id: 114, name: "Shadow Serpent Inner Disciple", attack: 27, defense: 16, health: 118, location: CombatArea.SHADOW_SERPENT_RAID, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Shadow Serpent Inner Disciple")}.webp`, loot: { items: [], weight: [] } },
+  { id: 115, name: "Shadow Serpent Core Disciple", attack: 33, defense: 20, health: 148, location: CombatArea.SHADOW_SERPENT_RAID, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Shadow Serpent Core Disciple")}.webp`, loot: { items: [], weight: [] } },
+
+  { id: 116, name: "Bone Abyss Outer Disciple", attack: 22, defense: 14, health: 95, location: CombatArea.BONE_ABYSS_RAID, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Bone Abyss Outer Disciple")}.webp`, loot: { items: [], weight: [] } },
+  { id: 117, name: "Bone Abyss Inner Disciple", attack: 28, defense: 18, health: 125, location: CombatArea.BONE_ABYSS_RAID, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Bone Abyss Inner Disciple")}.webp`, loot: { items: [], weight: [] } },
+  { id: 118, name: "Bone Abyss Core Disciple", attack: 34, defense: 22, health: 155, location: CombatArea.BONE_ABYSS_RAID, picture: `${TRAINING_ENEMIES}/${enemyImageSlug("Bone Abyss Core Disciple")}.webp`, loot: { items: [], weight: [] } },
 ];
 
 /** Base path for fishing area images. Add images under public/assets/fishing/ */

--- a/src/container/CombatContainer/CombatContainer.tsx
+++ b/src/container/CombatContainer/CombatContainer.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { enemies } from "../../constants/data";
+import { enemies, getSectRaidLootForRank, sectsData } from "../../constants/data";
 import { getCharacterImage, UI_ASSETS } from "../../constants/ui";
 import EnemyI from "../../interfaces/EnemyI";
 import EnemyLootPopover from "../../components/EnemyLootPopover/EnemyLootPopover";
@@ -12,6 +12,7 @@ import Item from "../../interfaces/ItemI";
 import { changeContent } from "../../state/reducers/contentSlice";
 import { ContentArea } from "../../enum/ContentArea";
 import { AREA_REALM_REQUIREMENTS, canEnterArea } from "../../constants/areaRealmRequirements";
+import { CombatArea } from "../../enum/CombatArea";
 
 const ENEMY_ATTACK_INTERVAL_MS = 3000;
 
@@ -163,8 +164,47 @@ const CombatContainer: React.FC<CombatAreaProps> = ({ area }) => {
    * Adds 1 item from the enemy drop table to the item bag. Techniques (qi/combat) are only added once per character; duplicates are skipped.
    */
   const addLootToItemBag = (enemy: EnemyI) => {
-    const items = enemy.loot?.items;
-    const weightRef = enemy.loot?.weight;
+    let items = enemy.loot?.items;
+    let weightRef = enemy.loot?.weight;
+
+    // For sect raid areas, build loot dynamically based on which sect is being raided and the raider's sect rank.
+    if (
+      area === CombatArea.JADE_MOUNTAIN_RAID ||
+      area === CombatArea.VERDANT_VALLEY_RAID ||
+      area === CombatArea.AZURE_SKY_RAID ||
+      area === CombatArea.CRIMSON_DEMON_RAID ||
+      area === CombatArea.SHADOW_SERPENT_RAID ||
+      area === CombatArea.BONE_ABYSS_RAID
+    ) {
+      const sectByArea: Record<string, number> = {
+        [CombatArea.JADE_MOUNTAIN_RAID]: 1,
+        [CombatArea.VERDANT_VALLEY_RAID]: 2,
+        [CombatArea.AZURE_SKY_RAID]: 3,
+        [CombatArea.CRIMSON_DEMON_RAID]: 4,
+        [CombatArea.SHADOW_SERPENT_RAID]: 5,
+        [CombatArea.BONE_ABYSS_RAID]: 6,
+      };
+      const sectId = sectByArea[area ?? ""];
+      const currentSect = character.currentSectId != null
+        ? sectsData.find((s) => s.id === character.currentSectId)
+        : null;
+
+      // Only allow cross-path raids: your own sect path vs opposing sect path.
+      if (
+        sectId != null &&
+        currentSect != null &&
+        currentSect.path === character.path
+      ) {
+        const targetSect = sectsData.find((s) => s.id === sectId);
+        if (targetSect && targetSect.path !== currentSect.path && character.sectRankIndex > 0) {
+          const loot = getSectRaidLootForRank(sectId, character.sectRankIndex);
+          if (loot) {
+            items = loot.items;
+            weightRef = loot.weight;
+          }
+        }
+      }
+    }
 
     if (!items) return;
     if (!weightRef) return;
@@ -268,8 +308,45 @@ const CombatContainer: React.FC<CombatAreaProps> = ({ area }) => {
   }, [fightingInterval]);
 
   const enemyLootEntries = useMemo(() => {
-    const items = currentEnemy?.loot?.items;
-    const weights = currentEnemy?.loot?.weight;
+    let items = currentEnemy?.loot?.items;
+    let weights = currentEnemy?.loot?.weight;
+
+    // Mirror dynamic loot logic for the popover so chances match actual drops.
+    if (
+      area === CombatArea.JADE_MOUNTAIN_RAID ||
+      area === CombatArea.VERDANT_VALLEY_RAID ||
+      area === CombatArea.AZURE_SKY_RAID ||
+      area === CombatArea.CRIMSON_DEMON_RAID ||
+      area === CombatArea.SHADOW_SERPENT_RAID ||
+      area === CombatArea.BONE_ABYSS_RAID
+    ) {
+      const sectByArea: Record<string, number> = {
+        [CombatArea.JADE_MOUNTAIN_RAID]: 1,
+        [CombatArea.VERDANT_VALLEY_RAID]: 2,
+        [CombatArea.AZURE_SKY_RAID]: 3,
+        [CombatArea.CRIMSON_DEMON_RAID]: 4,
+        [CombatArea.SHADOW_SERPENT_RAID]: 5,
+        [CombatArea.BONE_ABYSS_RAID]: 6,
+      };
+      const sectId = sectByArea[area ?? ""];
+      const currentSect = character.currentSectId != null
+        ? sectsData.find((s) => s.id === character.currentSectId)
+        : null;
+      if (
+        sectId != null &&
+        currentSect != null &&
+        currentSect.path === character.path
+      ) {
+        const targetSect = sectsData.find((s) => s.id === sectId);
+        if (targetSect && targetSect.path !== currentSect.path && character.sectRankIndex > 0) {
+          const loot = getSectRaidLootForRank(sectId, character.sectRankIndex);
+          if (loot) {
+            items = loot.items;
+            weights = loot.weight;
+          }
+        }
+      }
+    }
     if (!currentEnemy || !items?.length || !weights?.length || items.length !== weights.length)
       return [];
     const total = weights.reduce((a, b) => a + b, 0);

--- a/src/enum/CombatArea.ts
+++ b/src/enum/CombatArea.ts
@@ -31,4 +31,12 @@ export enum CombatArea {
 
   // Immortal
   PALACE = "Jade Immortal Court",
+
+  // Sect raid areas (not shown in Martial Training; used for cross-path sect battles)
+  JADE_MOUNTAIN_RAID = "Jade Mountain Sect Raid",
+  VERDANT_VALLEY_RAID = "Verdant Valley Sect Raid",
+  AZURE_SKY_RAID = "Azure Sky Pavilion Raid",
+  CRIMSON_DEMON_RAID = "Crimson Demon Sect Raid",
+  SHADOW_SERPENT_RAID = "Shadow Serpent Hall Raid",
+  BONE_ABYSS_RAID = "Bone Abyss Sect Raid",
 }


### PR DESCRIPTION
- Added functionality for players to battle opposing sects, allowing for dynamic loot based on sect rank during raids.
- Introduced new combat areas for sect raids and updated enemy definitions to reflect cross-path battles.
- Enhanced the SectWindow component to include battle options and eligibility checks for raiding.
- Updated the TODO documentation to reflect the addition of sect phase 3 and related features.