### PR TITLE
Add Auto-Loot Feature and Settings Integration

### DIFF
--- a/src/container/CombatContainer/CombatContainer.css
+++ b/src/container/CombatContainer/CombatContainer.css
@@ -153,6 +153,20 @@
   margin: 0 0 0.5rem;
   font-size: 1rem;
   color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.combatContainer__auto-loot-badge {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--accent);
+  background: var(--bg);
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid var(--accent);
 }
 
 .combatContainer__loot-empty {

--- a/src/container/CombatContainer/CombatContainer.tsx
+++ b/src/container/CombatContainer/CombatContainer.tsx
@@ -94,10 +94,12 @@ const CombatContainer: React.FC<CombatAreaProps> = ({ area }) => {
   const lastCharAttackRef = useRef(Date.now());
   const lastEnemyAttackRef = useRef(Date.now());
   const ownedTechniqueIdsRef = useRef(ownedTechniqueIds);
+  const characterRef = useRef(character);
 
   characterStateRef.current = characterState;
   currentEnemyRef.current = currentEnemy ?? null;
   ownedTechniqueIdsRef.current = ownedTechniqueIds;
+  characterRef.current = character;
 
   // Redirect if no valid area, no enemies, or realm too low for this area
   useEffect(() => {
@@ -162,14 +164,13 @@ const CombatContainer: React.FC<CombatAreaProps> = ({ area }) => {
   };
 
   /**
-   * Adds 1 item from the enemy drop table to the item bag. Techniques (qi/combat) are only added once per character; duplicates are skipped.
-   * Calls onItemDropped with the item when one is actually added (for activity log).
+   * Rolls once on the enemy loot table; returns the dropped item or null (e.g. technique already owned).
+   * Uses same logic as addLootToItemBag for sect raids vs normal.
    */
-  const addLootToItemBag = (enemy: EnemyI, onItemDropped?: (item: Item) => void) => {
+  const rollOneLootDrop = (enemy: EnemyI): Item | null => {
     let items = enemy.loot?.items;
     let weightRef = enemy.loot?.weight;
 
-    // For sect raid areas, build loot dynamically based on which sect is being raided and the raider's sect rank.
     if (
       area === CombatArea.JADE_MOUNTAIN_RAID ||
       area === CombatArea.VERDANT_VALLEY_RAID ||
@@ -190,8 +191,6 @@ const CombatContainer: React.FC<CombatAreaProps> = ({ area }) => {
       const currentSect = character.currentSectId != null
         ? sectsData.find((s) => s.id === character.currentSectId)
         : null;
-
-      // Only allow cross-path raids: your own sect path vs opposing sect path.
       if (
         sectId != null &&
         currentSect != null &&
@@ -208,26 +207,30 @@ const CombatContainer: React.FC<CombatAreaProps> = ({ area }) => {
       }
     }
 
-    if (!items) return;
-    if (!weightRef) return;
+    if (!items?.length || !weightRef?.length || items.length !== weightRef.length) return null;
 
     const weights = weightRef.slice();
-    let i: number;
-
-    for (i = 0; i < weights.length; i++) {
+    for (let i = 0; i < weights.length; i++) {
       weights[i] += weights[i - 1] || 0;
     }
-
     const random = Math.random() * weights[weights.length - 1];
-
-    for (i = 0; i < weights.length; i++) {
+    let i = 0;
+    for (; i < weights.length; i++) {
       if (weights[i] > random) break;
     }
-
     const dropped = items[i];
     const isTechnique = dropped.equipmentSlot === "qiTechnique" || dropped.equipmentSlot === "combatTechnique";
-    if (isTechnique && ownedTechniqueIdsRef.current.has(dropped.id)) return;
+    if (isTechnique && ownedTechniqueIdsRef.current.has(dropped.id)) return null;
+    return dropped;
+  };
 
+  /**
+   * Adds 1 item from the enemy drop table to the item bag. Techniques (qi/combat) are only added once per character; duplicates are skipped.
+   * Calls onItemDropped with the item when one is actually added (for activity log).
+   */
+  const addLootToItemBag = (enemy: EnemyI, onItemDropped?: (item: Item) => void) => {
+    const dropped = rollOneLootDrop(enemy);
+    if (!dropped) return;
     onItemDropped?.(dropped);
     setItemBag((prevItems) => [...prevItems, dropped]);
   };
@@ -252,8 +255,18 @@ const CombatContainer: React.FC<CombatAreaProps> = ({ area }) => {
       if (newHealth <= 0) {
         dispatch(addLogEntry({ type: "enemy_killed", enemyName: enemy.name }));
         setLastDamageToEnemy(null);
-        addLootToItemBag(enemy, (item) => dispatch(addLogEntry({ type: "item_obtained", itemName: item.name })));
-        setLootSpiritStones((prev) => prev + getSpiritStonesFromEnemy(enemy));
+        const spiritStones = getSpiritStonesFromEnemy(enemy);
+        if (characterRef.current.autoLoot) {
+          dispatch(addMoney(spiritStones));
+          const droppedItem = rollOneLootDrop(enemy);
+          if (droppedItem) {
+            dispatch(addItems([droppedItem]));
+            dispatch(addLogEntry({ type: "item_obtained", itemName: droppedItem.name }));
+          }
+        } else {
+          addLootToItemBag(enemy, (item) => dispatch(addLogEntry({ type: "item_obtained", itemName: item.name })));
+          setLootSpiritStones((prev) => prev + spiritStones);
+        }
         setCurrentEnemy(getRandomEnemy());
       }
     } else {
@@ -469,7 +482,10 @@ const CombatContainer: React.FC<CombatAreaProps> = ({ area }) => {
         </div>
       </div>
       <section className="combatContainer__loot">
-        <h4 className="combatContainer__loot-title">Loot bag</h4>
+        <h4 className="combatContainer__loot-title">
+          Loot bag
+          {character.autoLoot && <span className="combatContainer__auto-loot-badge">Auto-Loot: On</span>}
+        </h4>
         {itemBag.length === 0 && lootSpiritStones === 0 ? (
           <p className="combatContainer__loot-empty">No loot yet</p>
         ) : (

--- a/src/container/SettingsContainer/SettingsContainer.css
+++ b/src/container/SettingsContainer/SettingsContainer.css
@@ -154,3 +154,22 @@
   color: var(--text-muted);
   margin: 0;
 }
+
+/* ── Toggle row ── */
+.settings__toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+.settings__toggle-label {
+  flex: 1;
+}
+
+.settings__checkbox {
+  width: 1.15rem;
+  height: 1.15rem;
+  accent-color: var(--accent);
+}

--- a/src/container/SettingsContainer/SettingsContainer.tsx
+++ b/src/container/SettingsContainer/SettingsContainer.tsx
@@ -1,11 +1,13 @@
 import React, { useRef, useState } from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../../state/store";
 import { formatRealm } from "../../constants/realmProgression";
+import { setAutoLoot } from "../../state/reducers/characterSlice";
 import { exportSave, importSave, hardReset, formatSaveDate } from "../../utils/saveManager";
 import "./SettingsContainer.css";
 
 export const SettingsContainer = () => {
+  const dispatch = useDispatch();
   const character = useSelector((state: RootState) => state.character);
 
   const [exportMsg, setExportMsg] = useState<string | null>(null);
@@ -94,6 +96,25 @@ export const SettingsContainer = () => {
           <p className="settings__info">Last saved: {formatSaveDate(lastSaved)}</p>
         )}
       </div>
+
+      {/* Gameplay */}
+      {character.autoLootUnlocked && (
+        <div className="settings__section">
+          <h3 className="settings__section-title">Gameplay</h3>
+          <label className="settings__toggle-row">
+            <span className="settings__toggle-label">Auto-Loot (combat)</span>
+            <input
+              type="checkbox"
+              checked={!!character.autoLoot}
+              onChange={(e) => dispatch(setAutoLoot(e.target.checked))}
+              className="settings__checkbox"
+            />
+          </label>
+          <p className="settings__section-desc">
+            When on, loot and spirit stones from defeated enemies go straight to your inventory. Kept after reincarnation.
+          </p>
+        </div>
+      )}
 
       {/* Export */}
       <div className="settings__section">

--- a/src/container/Shop/Shop.css
+++ b/src/container/Shop/Shop.css
@@ -33,3 +33,9 @@
   gap: 1rem;
   justify-content: flex-start;
 }
+
+.shop__poor {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}

--- a/src/container/Shop/Shop.tsx
+++ b/src/container/Shop/Shop.tsx
@@ -1,10 +1,29 @@
 import React from "react";
-
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "../../state/store";
+import { purchaseAutoLootUnlock } from "../../state/reducers/characterSlice";
 import { existingShopItemUpgrades, existingShopItems, existingShopQiTechniques, existingShopCombatTechniques } from "../../constants/data";
 import "./Shop.css";
 import ShopItem from "../../components/ShopItem/ShopItem";
 
+const AUTO_LOOT_PRICE = 5000;
+
 export const Shop = () => {
+  const dispatch = useDispatch();
+  const money = useSelector((state: RootState) => state.character.money);
+  const autoLootUnlocked = useSelector((state: RootState) => state.character.autoLootUnlocked);
+  const [showPoor, setShowPoor] = React.useState(false);
+
+  const buyAutoLoot = () => {
+    if (autoLootUnlocked) return;
+    if (money < AUTO_LOOT_PRICE) {
+      setShowPoor(true);
+      return;
+    }
+    setShowPoor(false);
+    dispatch(purchaseAutoLootUnlock());
+  };
+
   return (
     <>
       <h2>Shop</h2>
@@ -13,6 +32,21 @@ export const Shop = () => {
           {existingShopItemUpgrades.map((item, index) => (
             <ShopItem key={index} item={item} />
           ))}
+        </div>
+        <h3>Combat upgrades</h3>
+        <div className="shop__main-upgrades">
+          <div className="shopitem__main">
+            <h3>Auto-Loot</h3>
+            <p>Loot and spirit stones from defeated enemies go straight to your inventory. No need to click Loot.</p>
+            <p>Cost: {AUTO_LOOT_PRICE} Spirit Stones</p>
+            {!autoLootUnlocked && (
+              <>
+                <button type="button" onClick={buyAutoLoot}>Buy</button>
+                {showPoor && <p className="shop__poor">Not enough Spirit Stones</p>}
+              </>
+            )}
+            {autoLootUnlocked && <p className="shopitem__already">Already purchased</p>}
+          </div>
         </div>
         <h3>Consumables</h3>
         <div className="shop__main-items">

--- a/src/state/reducers/characterSlice.ts
+++ b/src/state/reducers/characterSlice.ts
@@ -157,6 +157,10 @@ interface CharacterState {
   totalKarmaEarned: number;
   /** Purchased levels for each karma bonus. */
   karmaBonusLevels: Partial<Record<KarmaBonusId, number>>;
+  /** Whether the player has purchased the Auto-Loot upgrade (persists through reincarnation). */
+  autoLootUnlocked: boolean;
+  /** When true, combat loot and spirit stones go straight to inventory on kill (persists through reincarnation). */
+  autoLoot: boolean;
 }
 
 /** Display-only summary for the Welcome Back modal (no item lists). */
@@ -228,6 +232,8 @@ const initialState: CharacterState = {
   karmaPoints: 0,
   totalKarmaEarned: 0,
   karmaBonusLevels: {},
+  autoLootUnlocked: false,
+  autoLoot: false,
 };
 
 export const characterSlice = createSlice({
@@ -850,6 +856,19 @@ export const characterSlice = createSlice({
       state.karmaPoints -= bonus.costPerLevel;
       state.karmaBonusLevels[action.payload] = currentLevel + 1;
     },
+    /** One-time purchase: unlock Auto-Loot for 500 spirit stones. Persists through reincarnation. */
+    purchaseAutoLootUnlock: (state) => {
+      if (state.autoLootUnlocked) return;
+      if (state.money < 500) return;
+      state.money -= 500;
+      state.autoLootUnlocked = true;
+      state.autoLoot = true;
+    },
+    /** Toggle Auto-Loot on/off (only when unlocked). Persists through reincarnation. */
+    setAutoLoot: (state, action: PayloadAction<boolean>) => {
+      if (!state.autoLootUnlocked) return;
+      state.autoLoot = action.payload;
+    },
   },
 });
 
@@ -907,6 +926,8 @@ export const {
   clearOfflineSummary,
   reincarnate,
   purchaseKarmaBonus,
+  purchaseAutoLootUnlock,
+  setAutoLoot,
 } = characterSlice.actions;
 
 export default characterSlice.reducer;


### PR DESCRIPTION
- Implemented Auto-Loot functionality allowing players to automatically collect loot and spirit stones from defeated enemies.
- Added a toggle in the SettingsContainer for enabling/disabling Auto-Loot, which persists through reincarnation.
- Updated the Shop component to include an option for purchasing the Auto-Loot upgrade.
- Enhanced CombatContainer to reflect Auto-Loot status in the UI and adjust loot handling accordingly.
- Introduced new CSS styles for Auto-Loot badge and settings toggle for improved user experience.