### PR TITLE
Add Sect Phase 3 Features and NPC Relationships

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,14 +1,6 @@
 # TODO
 
-
-
 ## Next Version
-- Add more combat loot
-
-- Sect phase 3. Relationships
-- All skill expansion with content to level 120
-
-
 - **Polish** – Sound and VFX (hits, blocks, kill), tooltips (e.g. how block/damage work).
 
 ---
@@ -28,6 +20,36 @@ Rare combat-only drops (weapons, armor, rings, amulets). Place under `public/ass
 - `cloudsea-lotus-pendant.webp` (SEA)
 - `thunderbrand.webp` (STORM)
 - `jade-court-sigil.webp` (PALACE)
+
+---
+
+## Sect Phase 3 – Relationships (images needed)
+
+Sect quest rewards and romanceable NPCs. Paths are under `public/`.
+
+### Sect treasures (quest rewards)
+
+Place under `public/assets/sect-treasures/`:
+
+- `jade-mountain-heartstone.webp` (Jade Mountain Sect – ring)
+- `verdant-valley-heirloom.webp` (Verdant Valley Sect – amulet)
+- `azure-sky-sigil.webp` (Azure Sky Pavilion – amulet)
+- `crimson-demon-brand.webp` (Crimson Demon Sect – ring)
+- `shadow-serpent-fang.webp` (Shadow Serpent Hall – ring)
+- `bone-abyss-relic.webp` (Bone Abyss Sect – amulet)
+
+### Romanceable NPCs (2 images per character: portrait + lotus)
+
+Place under `public/assets/sect-npcs/{sectId}/` where `sectId` is 1–6 (Jade Mountain=1, Verdant Valley=2, Azure Sky=3, Crimson Demon=4, Shadow Serpent=5, Bone Abyss=6).
+
+**Sect 1 – Jade Mountain:** `101-portrait.webp`, `101-lotus.webp`, `102-portrait.webp`, `102-lotus.webp`, `103-portrait.webp`, `103-lotus.webp`, `104-portrait.webp`, `104-lotus.webp`  
+**Sect 2 – Verdant Valley:** `105-portrait.webp`, `105-lotus.webp`, … through `108-lotus.webp`  
+**Sect 3 – Azure Sky:** `109-portrait.webp` through `112-lotus.webp`  
+**Sect 4 – Crimson Demon:** `113-portrait.webp` through `116-lotus.webp`  
+**Sect 5 – Shadow Serpent:** `117-portrait.webp` through `120-lotus.webp`  
+**Sect 6 – Bone Abyss:** `121-portrait.webp` through `124-lotus.webp`
+
+(24 NPCs × 2 = 48 images total. Portrait = dialogue/casual; lotus = shown in meditation when chosen as cultivation partner.)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "idlegame",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/constants/sectRelationships.ts
+++ b/src/constants/sectRelationships.ts
@@ -1,0 +1,218 @@
+/**
+ * Sect Phase 3: NPCs, quests, and relationship data.
+ * One quest chain per sect (bulletin board), romanceable NPCs (2 per gender per sect),
+ * and sect treasure rewards (unique, not reset on reincarnation).
+ */
+import type Item from "../interfaces/ItemI";
+import type { EquipmentSlot } from "../types/EquipmentSlot";
+
+const SECT_NPC_ASSETS = "/assets/sect-npcs";
+
+/** Romanceable NPC: same sect only, gift spirit stones + realm dialogue for favor. 0–100 favor; at 50+ can dual cultivate. */
+export interface SectNpcI {
+  id: number;
+  sectId: number;
+  name: string;
+  gender: "Male" | "Female";
+  /** Flavor line for dialogue */
+  description: string;
+  /** Casual/dialogue portrait. Path under public: SECT_NPC_ASSETS/{sectId}/{id}-portrait.webp */
+  portraitImage: string;
+  /** Lotus pose when chosen as cultivation partner. SECT_NPC_ASSETS/{sectId}/{id}-lotus.webp */
+  lotusImage: string;
+}
+
+/** Global NPC id base per sect: sect 1 = 101-104, sect 2 = 105-108, ... */
+function npcId(sectId: number, index: number): number {
+  return (sectId - 1) * 4 + 101 + index;
+}
+
+/** Build NPCs for all 6 sects: 2 Male, 2 Female per sect. */
+export function getSectNpcs(): SectNpcI[] {
+  const sects: { id: number; name: string }[] = [
+    { id: 1, name: "Jade Mountain Sect" },
+    { id: 2, name: "Verdant Valley Sect" },
+    { id: 3, name: "Azure Sky Pavilion" },
+    { id: 4, name: "Crimson Demon Sect" },
+    { id: 5, name: "Shadow Serpent Hall" },
+    { id: 6, name: "Bone Abyss Sect" },
+  ];
+  const out: SectNpcI[] = [];
+  const maleNames = [
+    ["Wei Lin", "Jiang Chen"],
+    ["Ming Hao", "Yuan Feng"],
+    ["Kai Wen", "Rui Ziang"],
+    ["Xue Long", "Mo Kai"],
+    ["Shan Zhu", "Ye Ming"],
+    ["Bai Gu", "Hei Yan"],
+  ];
+  const femaleNames = [
+    ["Mei Ling", "Xiu Yan"],
+    ["Lan Yi", "Jing Wei"],
+    ["Yun Xue", "Xin Yue"],
+    ["Xue Mei", "Ling Po"],
+    ["An Jing", "Yin Hua"],
+    ["Gu Hun", "You Ling"],
+  ];
+  for (let s = 0; s < sects.length; s++) {
+    const sect = sects[s];
+    for (let i = 0; i < 4; i++) {
+      const id = npcId(sect.id, i);
+      const isMale = i < 2;
+      const names = isMale ? maleNames[s] : femaleNames[s];
+      const name = names[i % 2];
+      out.push({
+        id,
+        sectId: sect.id,
+        name,
+        gender: isMale ? "Male" : "Female",
+        description: `A disciple of ${sect.name}.`,
+        portraitImage: `${SECT_NPC_ASSETS}/${sect.id}/${id}-portrait.webp`,
+        lotusImage: `${SECT_NPC_ASSETS}/${sect.id}/${id}-lotus.webp`,
+      });
+    }
+  }
+  return out;
+}
+
+export const SECT_NPCS = getSectNpcs();
+
+export const SECT_NPCS_BY_SECT: Record<number, SectNpcI[]> = SECT_NPCS.reduce(
+  (acc, npc) => {
+    if (!acc[npc.sectId]) acc[npc.sectId] = [];
+    acc[npc.sectId].push(npc);
+    return acc;
+  },
+  {} as Record<number, SectNpcI[]>
+);
+
+export function getSectNpcById(npcId: number): SectNpcI | undefined {
+  return SECT_NPCS.find((n) => n.id === npcId);
+}
+
+/** Quest step: 0 = not started, 1 = in progress (kill 15 enemies), 2 = ready to claim, 3 = claimed */
+export const SECT_QUEST_KILLS_REQUIRED = 15;
+
+/** Sect treasure item ids (unique, one per sect, from quest reward). Not reset on reincarnation. */
+export const SECT_TREASURE_IDS = {
+  jadeMountain: 981,
+  verdantValley: 982,
+  azureSky: 983,
+  crimsonDemon: 984,
+  shadowSerpent: 985,
+  boneAbyss: 986,
+} as const;
+
+const SECT_TREASURES_ASSETS = "/assets/sect-treasures";
+
+/** Sect id to treasure item id */
+export const SECT_TREASURE_ITEM_ID_BY_SECT: Record<number, number> = {
+  1: SECT_TREASURE_IDS.jadeMountain,
+  2: SECT_TREASURE_IDS.verdantValley,
+  3: SECT_TREASURE_IDS.azureSky,
+  4: SECT_TREASURE_IDS.crimsonDemon,
+  5: SECT_TREASURE_IDS.shadowSerpent,
+  6: SECT_TREASURE_IDS.boneAbyss,
+};
+
+/** Sect treasure items: names derived from sect. One-time obtainable from quest. */
+export const SECT_TREASURE_ITEMS: (Item & { equipmentSlot: EquipmentSlot })[] = [
+  {
+    id: SECT_TREASURE_IDS.jadeMountain,
+    name: "Jade Mountain Heartstone",
+    description: "Sect-defining treasure of the Jade Mountain Sect. Earned by proving your worth.",
+    price: 0,
+    quantity: 1,
+    picture: `${SECT_TREASURES_ASSETS}/jade-mountain-heartstone.webp`,
+    equipmentSlot: "ring",
+    attackBonus: 2,
+    defenseBonus: 2,
+  },
+  {
+    id: SECT_TREASURE_IDS.verdantValley,
+    name: "Verdant Valley Heirloom",
+    description: "Sect-defining treasure of the Verdant Valley Sect.",
+    price: 0,
+    quantity: 1,
+    picture: `${SECT_TREASURES_ASSETS}/verdant-valley-heirloom.webp`,
+    equipmentSlot: "amulet",
+    vitalityBonus: 5,
+    qiGainBonus: 3,
+  },
+  {
+    id: SECT_TREASURE_IDS.azureSky,
+    name: "Azure Sky Sigil",
+    description: "Sect-defining treasure of the Azure Sky Pavilion.",
+    price: 0,
+    quantity: 1,
+    picture: `${SECT_TREASURES_ASSETS}/azure-sky-sigil.webp`,
+    equipmentSlot: "amulet",
+    qiGainBonus: 8,
+  },
+  {
+    id: SECT_TREASURE_IDS.crimsonDemon,
+    name: "Crimson Demon Brand",
+    description: "Sect-defining treasure of the Crimson Demon Sect.",
+    price: 0,
+    quantity: 1,
+    picture: `${SECT_TREASURES_ASSETS}/crimson-demon-brand.webp`,
+    equipmentSlot: "ring",
+    attackBonus: 4,
+  },
+  {
+    id: SECT_TREASURE_IDS.shadowSerpent,
+    name: "Shadow Serpent Fang",
+    description: "Sect-defining treasure of the Shadow Serpent Hall.",
+    price: 0,
+    quantity: 1,
+    picture: `${SECT_TREASURES_ASSETS}/shadow-serpent-fang.webp`,
+    equipmentSlot: "ring",
+    attackBonus: 2,
+    attackSpeedReduction: 30,
+  },
+  {
+    id: SECT_TREASURE_IDS.boneAbyss,
+    name: "Bone Abyss Relic",
+    description: "Sect-defining treasure of the Bone Abyss Sect.",
+    price: 0,
+    quantity: 1,
+    picture: `${SECT_TREASURES_ASSETS}/bone-abyss-relic.webp`,
+    equipmentSlot: "amulet",
+    defenseBonus: 4,
+    vitalityBonus: 4,
+  },
+];
+
+export function getSectTreasureItemById(id: number): Item | undefined {
+  return SECT_TREASURE_ITEMS.find((i) => i.id === id);
+}
+
+/** Major realms that unlock one-time dialogue with NPCs (favor boost). */
+export const REALM_DIALOGUE_REALMS: string[] = [
+  "Qi Condensation",
+  "Foundation Establishment",
+  "Golden Core",
+  "Nascent Soul",
+  "Soul Formation",
+  "Void Refinement",
+  "Body Integration",
+  "Mahayana",
+  "Tribulation Transcendent",
+  "Immortal",
+];
+
+/** Favor gain from using realm dialogue once per realm */
+export const REALM_DIALOGUE_FAVOR = 5;
+
+/** Minimum favor to select as dual cultivation partner */
+export const DUAL_CULTIVATION_MIN_FAVOR = 50;
+
+/** Spirit stones per gift; each gift gives 1 favor (capped at 100) */
+export const GIFT_SPIRIT_STONE_COST = 100;
+
+/** Dual cultivation: qi/s bonus at 50 favor = 0%, at 100 favor = 15% (linear scale) */
+export function getDualCultivationBonusPercent(favor: number): number {
+  if (favor < DUAL_CULTIVATION_MIN_FAVOR) return 0;
+  const t = (favor - DUAL_CULTIVATION_MIN_FAVOR) / (100 - DUAL_CULTIVATION_MIN_FAVOR);
+  return Math.min(15, t * 15);
+}

--- a/src/container/CombatContainer/CombatContainer.tsx
+++ b/src/container/CombatContainer/CombatContainer.tsx
@@ -6,7 +6,7 @@ import EnemyLootPopover from "../../components/EnemyLootPopover/EnemyLootPopover
 import "./CombatContainer.css";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../../state/store";
-import { addItems, addMoney, consumeItems, setCurrentHealth, setWeakened, recordEnemyKill, recordDeath } from "../../state/reducers/characterSlice";
+import { addItems, addMoney, consumeItems, setCurrentHealth, setWeakened, recordEnemyKill, recordDeath, incrementSectQuestKillCount } from "../../state/reducers/characterSlice";
 import { addLogEntry } from "../../state/reducers/logSlice";
 import { getEffectiveCombatStats, getOwnedTechniqueIds, getTalentSpiritStoneMultiplier } from "../../state/selectors/characterSelectors";
 import Item from "../../interfaces/ItemI";
@@ -290,6 +290,8 @@ const CombatContainer: React.FC<CombatAreaProps> = ({ area }) => {
       if (newHealth <= 0) {
         dispatch(addLogEntry({ type: "enemy_killed", enemyName: enemy.name }));
         if (area) dispatch(recordEnemyKill(area));
+        const sectId = characterRef.current.currentSectId;
+        if (sectId != null) dispatch(incrementSectQuestKillCount(sectId));
         setLastDamageToEnemy(null);
         const spiritStones = Math.floor(getSpiritStonesFromEnemy(enemy) * talentSpiritStoneMultRef.current);
         if (characterRef.current.autoLoot) {

--- a/src/container/MeditationContainer/MeditationContainer.css
+++ b/src/container/MeditationContainer/MeditationContainer.css
@@ -141,6 +141,33 @@
   text-align: center;
 }
 
+.meditation-container__partner-bonus {
+  color: var(--accent);
+  font-size: 0.85em;
+}
+
+.meditation-container__partner-wrap {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.meditation-container__partner-label {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-bottom: 0.25rem;
+}
+
+.meditation-container__partner-select {
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text);
+}
+
 .meditation-container__start,
 .meditation-container__stop {
   margin-bottom: 0.5rem;

--- a/src/container/MeditationContainer/MeditationContainer.tsx
+++ b/src/container/MeditationContainer/MeditationContainer.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../../state/store";
-import { breakthrough, setCurrentActivity } from "../../state/reducers/characterSlice";
+import { breakthrough, setCurrentActivity, setCultivationPartner } from "../../state/reducers/characterSlice";
 import { formatRealm, getBreakthroughQiRequired, getNextRealm, getBreakthroughStatGainText } from "../../constants/realmProgression";
 import { ACTIVITY_LABELS } from "../../constants/activities";
 import { BASE_QI_PER_SECOND } from "../../constants/meditation";
 import { getCharacterImage } from "../../constants/ui";
-import { getKarmaQiMultiplier, getTalentQiGainBonus } from "../../state/selectors/characterSelectors";
+import { getKarmaQiMultiplier, getTalentQiGainBonus, getCultivationPartnerInfo } from "../../state/selectors/characterSelectors";
+import { SECT_NPCS_BY_SECT, DUAL_CULTIVATION_MIN_FAVOR } from "../../constants/sectRelationships";
 import { Tooltip } from "../../components/Tooltip/Tooltip";
 import { WEAKENED_MEDITATION_SECONDS } from "../../state/reducers/characterSlice";
 import "./MeditationContainer.css";
@@ -16,11 +17,15 @@ export const MeditationContainer = () => {
   const character = useSelector((state: RootState) => state.character);
   const karmaQiMult = useSelector(getKarmaQiMultiplier);
   const talentQiGain = useSelector(getTalentQiGainBonus);
+  const partnerInfo = useSelector(getCultivationPartnerInfo);
+  const currentSectId = useSelector((state: RootState) => state.character.currentSectId);
+  const npcFavor = useSelector((state: RootState) => state.character.npcFavor);
   const { realm, realmLevel, qi, currentActivity, equipment } = character;
   const isWeakened = character.isWeakened && character.deathPenaltyMode === "normal";
   const weakenedRemaining = Math.max(0, WEAKENED_MEDITATION_SECONDS - (character.weakenedMeditationSecondsDone ?? 0));
   const qiTechnique = equipment.qiTechnique;
-  const baseQiPerSecond = BASE_QI_PER_SECOND + (qiTechnique?.qiGainBonus ?? 0) + (equipment.amulet?.qiGainBonus ?? 0) + talentQiGain;
+  const partnerBonusMult = 1 + (partnerInfo.bonusPercent ?? 0) / 100;
+  const baseQiPerSecond = (BASE_QI_PER_SECOND + (qiTechnique?.qiGainBonus ?? 0) + (equipment.amulet?.qiGainBonus ?? 0) + talentQiGain) * partnerBonusMult;
   const qiPerSecond = Math.round(baseQiPerSecond * karmaQiMult * 100) / 100;
   const requiredQi = getBreakthroughQiRequired(realm, realmLevel);
   const nextRealm = getNextRealm(realm, realmLevel);
@@ -70,11 +75,20 @@ export const MeditationContainer = () => {
         </p>
       )}
       <div className="meditation-container__character">
-        <img
-          src={getCharacterImage(character.gender ?? "Male", "lotus")}
-          alt="Meditating"
-          className="meditation-container__character-img"
-        />
+        {partnerInfo.npc ? (
+          <img
+            src={partnerInfo.npc.lotusImage}
+            alt={`Cultivation partner: ${partnerInfo.npc.name}`}
+            className="meditation-container__character-img"
+            title={`Dual cultivation with ${partnerInfo.npc.name} (+${partnerInfo.bonusPercent}% Qi/s)`}
+          />
+        ) : (
+          <img
+            src={getCharacterImage(character.gender ?? "Male", "lotus")}
+            alt="Meditating"
+            className="meditation-container__character-img"
+          />
+        )}
         {canBreakthrough && (
           <button
             type="button"
@@ -110,8 +124,45 @@ export const MeditationContainer = () => {
         )}
         <p className={`meditation-container__qi-rate ${isMeditating ? "meditation-container__qi-rate--active" : ""}`}>
           {isMeditating ? `+${displayRate} Qi/s` : `${displayRate} Qi/s (when meditating)`}
+          {partnerInfo.bonusPercent > 0 && (
+            <span className="meditation-container__partner-bonus" title={`Dual cultivation: +${partnerInfo.bonusPercent}%`}>
+              {" "}(+{partnerInfo.bonusPercent}% partner)
+            </span>
+          )}
         </p>
       </div>
+      {currentSectId != null && (SECT_NPCS_BY_SECT[currentSectId] ?? []).filter(
+        (npc) => (npcFavor[`${currentSectId}-${npc.id}`] ?? 0) >= DUAL_CULTIVATION_MIN_FAVOR
+      ).length > 0 && (
+        <div className="meditation-container__partner-wrap">
+          <label htmlFor="meditation-partner-select" className="meditation-container__partner-label">
+            Cultivation partner
+          </label>
+          <select
+            id="meditation-partner-select"
+            className="meditation-container__partner-select"
+            value={partnerInfo.npc ? `${partnerInfo.npc.sectId}-${partnerInfo.npc.id}` : ""}
+            onChange={(e) => {
+              const v = e.target.value;
+              if (!v) {
+                dispatch(setCultivationPartner(null));
+                return;
+              }
+              const [sectId, npcId] = v.split("-").map(Number);
+              if (sectId && npcId) dispatch(setCultivationPartner({ sectId, npcId }));
+            }}
+          >
+            <option value="">None</option>
+            {(SECT_NPCS_BY_SECT[currentSectId] ?? [])
+              .filter((npc) => (npcFavor[`${currentSectId}-${npc.id}`] ?? 0) >= DUAL_CULTIVATION_MIN_FAVOR)
+              .map((npc) => (
+                <option key={npc.id} value={`${npc.sectId}-${npc.id}`}>
+                  {npc.name} ({(npcFavor[`${npc.sectId}-${npc.id}`] ?? 0)} favor)
+                </option>
+              ))}
+          </select>
+        </div>
+      )}
       {!isMeditating ? (
         <>
           <button

--- a/src/container/SectContainer/SectContainer.css
+++ b/src/container/SectContainer/SectContainer.css
@@ -201,3 +201,88 @@
 .sectContainer__btn--secondary:hover {
   border-color: var(--accent);
 }
+
+.sectContainer__tabs {
+  display: flex;
+  gap: 0;
+  margin: 1rem 0 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.sectContainer__tab {
+  padding: 0.5rem 1rem;
+  font-size: 0.95em;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  cursor: pointer;
+  color: var(--text-muted);
+}
+
+.sectContainer__tab:hover {
+  color: var(--text);
+}
+
+.sectContainer__tab--active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  font-weight: 600;
+}
+
+.sectContainer__npcGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-top: 0.75rem;
+}
+
+.sectContainer__npcCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.sectContainer__npcPortrait {
+  width: 100%;
+  aspect-ratio: 1;
+  object-fit: cover;
+  border-radius: 6px;
+  background: var(--border);
+}
+
+.sectContainer__npcInfo {
+  font-size: 0.9em;
+}
+
+.sectContainer__npcFavor {
+  margin: 0.25rem 0;
+  font-size: 0.85em;
+  color: var(--text-muted);
+}
+
+.sectContainer__npcActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.5rem;
+}
+
+.sectContainer__btn--small {
+  padding: 0.35rem 0.6rem;
+  font-size: 0.8em;
+}
+
+.sectContainer__btn--accent {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.sectContainer__btn--accent:hover {
+  background: var(--accent);
+  color: var(--bg);
+}

--- a/src/container/SectContainer/SectContainer.tsx
+++ b/src/container/SectContainer/SectContainer.tsx
@@ -2,12 +2,30 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../../state/store";
 import { changeContent } from "../../state/reducers/contentSlice";
-import { setSect, startPromotion, completePromotion } from "../../state/reducers/characterSlice";
+import {
+  setSect,
+  startPromotion,
+  completePromotion,
+  acceptSectQuest,
+  claimSectQuestReward,
+  giftNpc,
+  useRealmDialogue,
+  setCultivationPartner,
+} from "../../state/reducers/characterSlice";
 import { ContentArea } from "../../enum/ContentArea";
 import { getStepIndex } from "../../constants/realmProgression";
 import { sectsData, SECT_POSITIONS, sectStoreData } from "../../constants/data";
+import {
+  SECT_NPCS_BY_SECT,
+  SECT_QUEST_KILLS_REQUIRED,
+  REALM_DIALOGUE_REALMS,
+  DUAL_CULTIVATION_MIN_FAVOR,
+  GIFT_SPIRIT_STONE_COST,
+} from "../../constants/sectRelationships";
 import { SectStoreItem } from "../../components/SectStoreItem/SectStoreItem";
 import "./SectContainer.css";
+
+type SectTab = "store" | "bulletin" | "relationships";
 
 const PROMOTION_DURATION_MS = 5000;
 
@@ -20,6 +38,15 @@ export const SectContainer = () => {
   const realmLevel = useSelector((state: RootState) => state.character.realmLevel);
   const promotionEndTime = useSelector((state: RootState) => state.character.promotionEndTime);
   const promotionToRankIndex = useSelector((state: RootState) => state.character.promotionToRankIndex);
+  const sectQuestProgress = useSelector((state: RootState) => state.character.sectQuestProgress);
+  const sectQuestKillCount = useSelector((state: RootState) => state.character.sectQuestKillCount);
+  const obtainedSectTreasureIds = useSelector((state: RootState) => state.character.obtainedSectTreasureIds);
+  const npcFavor = useSelector((state: RootState) => state.character.npcFavor);
+  const realmDialogueUsed = useSelector((state: RootState) => state.character.realmDialogueUsed);
+  const cultivationPartner = useSelector((state: RootState) => state.character.cultivationPartner);
+  const money = useSelector((state: RootState) => state.character.money);
+
+  const [activeTab, setActiveTab] = useState<SectTab>("store");
 
   const currentSect = currentSectId != null ? sectsData.find((s) => s.id === currentSectId) : null;
   /** All sects on the same path (your sect + allied sects); you can buy from any of them based on your rank. */
@@ -141,6 +168,38 @@ export const SectContainer = () => {
         )}
       </div>
 
+      <div className="sectContainer__tabs" role="tablist">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === "store"}
+          className={`sectContainer__tab ${activeTab === "store" ? "sectContainer__tab--active" : ""}`}
+          onClick={() => setActiveTab("store")}
+        >
+          Store
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === "bulletin"}
+          className={`sectContainer__tab ${activeTab === "bulletin" ? "sectContainer__tab--active" : ""}`}
+          onClick={() => setActiveTab("bulletin")}
+        >
+          Bulletin Board
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === "relationships"}
+          className={`sectContainer__tab ${activeTab === "relationships" ? "sectContainer__tab--active" : ""}`}
+          onClick={() => setActiveTab("relationships")}
+        >
+          Relationships
+        </button>
+      </div>
+
+      {activeTab === "store" && (
+        <>
       <h3 className="sectContainer__storeTitle">Sect store</h3>
       <p className="sectContainer__hint">
         Your rank in your sect applies to all sects on your path. You can buy recipes and techniques from other {currentSect.path} sects without leaving your sect.
@@ -185,6 +244,131 @@ export const SectContainer = () => {
           </div>
         );
       })}
+
+      <p className="sectContainer__hint">
+        To join another sect, open the Map and select a sect. You must leave your current sect first.
+      </p>
+      <button type="button" className="sectContainer__btn sectContainer__btn--secondary" onClick={openMap}>
+        Open Map
+      </button>
+      <button type="button" className="sectContainer__btn sectContainer__btn--leave" onClick={handleLeave}>
+        Leave sect
+      </button>
+        </>
+      )}
+
+      {activeTab === "bulletin" && currentSectId != null && (
+        <div className="sectContainer__card">
+          <h3 className="sectContainer__storeTitle">Bulletin Board</h3>
+          {(() => {
+            const step = sectQuestProgress[currentSectId] ?? 0;
+            const kills = sectQuestKillCount[currentSectId] ?? 0;
+            if (step === 0) {
+              return (
+                <>
+                  <p className="sectContainer__hint">
+                    The board lists a task: prove your worth to the sect by defeating enemies in combat.
+                  </p>
+                  <button
+                    type="button"
+                    className="sectContainer__btn sectContainer__btn--primary"
+                    onClick={() => dispatch(acceptSectQuest(currentSectId))}
+                  >
+                    Accept quest
+                  </button>
+                </>
+              );
+            }
+            if (step === 1) {
+              return (
+                <p className="sectContainer__hint">
+                  Defeat {SECT_QUEST_KILLS_REQUIRED} enemies in combat. Progress: {kills} / {SECT_QUEST_KILLS_REQUIRED}
+                </p>
+              );
+            }
+            if (step === 2) {
+              return (
+                <>
+                  <p className="sectContainer__hint">You have proven yourself. Claim the sect&apos;s treasure.</p>
+                  <button
+                    type="button"
+                    className="sectContainer__btn sectContainer__btn--primary"
+                    onClick={() => dispatch(claimSectQuestReward(currentSectId))}
+                  >
+                    Claim reward
+                  </button>
+                </>
+              );
+            }
+            return (
+              <p className="sectContainer__hint">Quest complete. You have received this sect&apos;s defining treasure.</p>
+            );
+          })()}
+        </div>
+      )}
+
+      {activeTab === "relationships" && currentSectId != null && (
+        <div className="sectContainer__relationships">
+          <h3 className="sectContainer__storeTitle">Sect disciples</h3>
+          <p className="sectContainer__hint">
+            Gift spirit stones or talk (once per major realm) to increase favor. At {DUAL_CULTIVATION_MIN_FAVOR}+ favor you can choose them as dual cultivation partner in Meditation.
+          </p>
+          <div className="sectContainer__npcGrid">
+            {(SECT_NPCS_BY_SECT[currentSectId] ?? []).map((npc) => {
+              const key = `${npc.sectId}-${npc.id}`;
+              const favor = npcFavor[key] ?? 0;
+              const usedForRealm = realmDialogueUsed[key]?.[realm] === true;
+              const canTalk = realm !== "Mortal" && !usedForRealm && REALM_DIALOGUE_REALMS.includes(realm);
+              const isPartner = cultivationPartner?.sectId === npc.sectId && cultivationPartner?.npcId === npc.id;
+              const canBePartner = favor >= DUAL_CULTIVATION_MIN_FAVOR;
+              return (
+                <div key={npc.id} className="sectContainer__npcCard">
+                  <img src={npc.portraitImage} alt="" className="sectContainer__npcPortrait" />
+                  <div className="sectContainer__npcInfo">
+                    <strong>{npc.name}</strong> ({npc.gender})
+                    <p className="sectContainer__npcFavor">Favor: {favor}/100</p>
+                    <div className="sectContainer__npcActions">
+                      <button
+                        type="button"
+                        className="sectContainer__btn sectContainer__btn--small"
+                        onClick={() => dispatch(giftNpc({ sectId: npc.sectId, npcId: npc.id }))}
+                        disabled={money < GIFT_SPIRIT_STONE_COST || favor >= 100}
+                        title={`${GIFT_SPIRIT_STONE_COST} Spirit Stones → +1 Favor`}
+                      >
+                        Gift ({GIFT_SPIRIT_STONE_COST} SS)
+                      </button>
+                      {canTalk && (
+                        <button
+                          type="button"
+                          className="sectContainer__btn sectContainer__btn--small"
+                          onClick={() => dispatch(useRealmDialogue({ sectId: npc.sectId, npcId: npc.id, realmId: realm }))}
+                        >
+                          Talk ({realm})
+                        </button>
+                      )}
+                      {canBePartner && (
+                        <button
+                          type="button"
+                          className="sectContainer__btn sectContainer__btn--small sectContainer__btn--accent"
+                          onClick={() =>
+                            dispatch(
+                              setCultivationPartner(
+                                isPartner ? null : { sectId: npc.sectId, npcId: npc.id }
+                              )
+                            )
+                          }
+                        >
+                          {isPartner ? "Unset partner" : "Set as partner"}
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       <p className="sectContainer__hint">
         To join another sect, open the Map and select a sect. You must leave your current sect first.

--- a/src/state/reducers/characterSlice.ts
+++ b/src/state/reducers/characterSlice.ts
@@ -21,6 +21,13 @@ import {
   REINCARNATION_MIN_STEP,
 } from "../../constants/reincarnation";
 import {
+  SECT_TREASURE_ITEMS,
+  SECT_TREASURE_ITEM_ID_BY_SECT,
+  SECT_QUEST_KILLS_REQUIRED,
+  REALM_DIALOGUE_FAVOR,
+  GIFT_SPIRIT_STONE_COST,
+} from "../../constants/sectRelationships";
+import {
   AVATAR_CREATE_ORE_AMOUNT,
   AVATAR_CREATE_ORE_ID,
   AVATAR_CREATE_SPIRIT_STONES,
@@ -193,6 +200,18 @@ interface CharacterState {
   autoEat: boolean;
   /** HP percentage (1–99) below which auto-eat triggers. */
   autoEatHpPercent: number;
+  /** Sect quest: step 0=not started, 1=in progress, 2=ready to claim, 3=claimed. Not reset on reincarnation. */
+  sectQuestProgress: Record<number, number>;
+  /** Kills in current quest step (for step 1). Key = sectId. Not reset on reincarnation. */
+  sectQuestKillCount: Record<number, number>;
+  /** Sect treasure item ids already obtained (one-time per sect). Not reset on reincarnation. */
+  obtainedSectTreasureIds: number[];
+  /** NPC favor 0–100. Key = "sectId-npcId". Not reset on reincarnation. */
+  npcFavor: Record<string, number>;
+  /** Realm dialogue used per NPC. Key = "sectId-npcId", value = set of realm ids. Not reset on reincarnation. */
+  realmDialogueUsed: Record<string, Record<string, boolean>>;
+  /** Current dual cultivation partner (sect + npc). Not reset on reincarnation. */
+  cultivationPartner: { sectId: number; npcId: number } | null;
   /** Death penalty mode: "normal" = weakened state after death until meditation; "casual" = no weakened. */
   deathPenaltyMode: "normal" | "casual";
   /** After death (normal mode): true until player meditates for required seconds. */
@@ -307,6 +326,12 @@ const initialState: CharacterState = {
   autoEatUnlocked: false,
   autoEat: false,
   autoEatHpPercent: 30,
+  sectQuestProgress: {},
+  sectQuestKillCount: {},
+  obtainedSectTreasureIds: [],
+  npcFavor: {},
+  realmDialogueUsed: {},
+  cultivationPartner: null,
   deathPenaltyMode: "normal",
   isWeakened: false,
   weakenedMeditationSecondsDone: 0,
@@ -893,7 +918,8 @@ export const characterSlice = createSlice({
         item.equipmentSlot === "combatTechnique" ||
         item.equipmentSlot === "ring" ||
         item.equipmentSlot === "amulet" ||
-        item.skillSet != null;
+        item.skillSet != null ||
+        (item.id >= 981 && item.id <= 986);
 
       const preservedItems: Item[] = [];
       const seenIds = new Set<number>();
@@ -1006,6 +1032,69 @@ export const characterSlice = createSlice({
     setAutoEatHpPercent: (state, action: PayloadAction<number>) => {
       state.autoEatHpPercent = Math.min(99, Math.max(1, Math.round(action.payload)));
     },
+    /** Accept sect quest (step 0 → 1). Only when in sect and step is 0. */
+    acceptSectQuest: (state, action: PayloadAction<number>) => {
+      const sectId = action.payload;
+      if (state.currentSectId !== sectId) return;
+      const step = state.sectQuestProgress[sectId] ?? 0;
+      if (step !== 0) return;
+      state.sectQuestProgress[sectId] = 1;
+      state.sectQuestKillCount[sectId] = 0;
+    },
+    /** Increment sect quest kill count when player kills an enemy while in that sect and on step 1. */
+    incrementSectQuestKillCount: (state, action: PayloadAction<number>) => {
+      const sectId = action.payload;
+      if (state.currentSectId !== sectId) return;
+      const step = state.sectQuestProgress[sectId] ?? 0;
+      if (step !== 1) return;
+      const count = (state.sectQuestKillCount[sectId] ?? 0) + 1;
+      state.sectQuestKillCount[sectId] = count;
+      if (count >= SECT_QUEST_KILLS_REQUIRED) state.sectQuestProgress[sectId] = 2;
+    },
+    /** Claim sect quest reward (step 2 → 3). Gives sect treasure if not already obtained. */
+    claimSectQuestReward: (state, action: PayloadAction<number>) => {
+      const sectId = action.payload;
+      const step = state.sectQuestProgress[sectId] ?? 0;
+      if (step !== 2) return;
+      const itemId = SECT_TREASURE_ITEM_ID_BY_SECT[sectId];
+      if (itemId == null || state.obtainedSectTreasureIds.includes(itemId)) return;
+      const item = SECT_TREASURE_ITEMS.find((i) => i.id === itemId);
+      if (!item) return;
+      state.sectQuestProgress[sectId] = 3;
+      state.obtainedSectTreasureIds.push(itemId);
+      upsertItem(state.items, { ...item, quantity: 1 }, 1);
+    },
+    /** Add favor for an NPC (internal / from gift or dialogue). */
+    addNpcFavor: (state, action: PayloadAction<{ sectId: number; npcId: number; amount: number }>) => {
+      const { sectId, npcId, amount } = action.payload;
+      const key = `${sectId}-${npcId}`;
+      const current = state.npcFavor[key] ?? 0;
+      state.npcFavor[key] = Math.min(100, Math.max(0, current + amount));
+    },
+    /** Use one-time realm dialogue with NPC (increases favor, marks realm as used). */
+    useRealmDialogue: (state, action: PayloadAction<{ sectId: number; npcId: number; realmId: string }>) => {
+      const { sectId, npcId, realmId } = action.payload;
+      const key = `${sectId}-${npcId}`;
+      if (!state.realmDialogueUsed[key]) state.realmDialogueUsed[key] = {};
+      if (state.realmDialogueUsed[key][realmId]) return;
+      state.realmDialogueUsed[key][realmId] = true;
+      const current = state.npcFavor[key] ?? 0;
+      state.npcFavor[key] = Math.min(100, current + REALM_DIALOGUE_FAVOR);
+    },
+    /** Set or clear dual cultivation partner (only if favor >= 50 when setting). */
+    setCultivationPartner: (state, action: PayloadAction<{ sectId: number; npcId: number } | null>) => {
+      state.cultivationPartner = action.payload;
+    },
+    /** Gift spirit stones to NPC to increase favor. Cost GIFT_SPIRIT_STONE_COST per gift, +1 favor. */
+    giftNpc: (state, action: PayloadAction<{ sectId: number; npcId: number }>) => {
+      const { sectId, npcId } = action.payload;
+      if (state.currentSectId !== sectId) return;
+      if (state.money < GIFT_SPIRIT_STONE_COST) return;
+      state.money -= GIFT_SPIRIT_STONE_COST;
+      const key = `${sectId}-${npcId}`;
+      const current = state.npcFavor[key] ?? 0;
+      state.npcFavor[key] = Math.min(100, current + 1);
+    },
     /** Death penalty: "normal" = weakened after death; "casual" = no weakened. */
     setDeathPenaltyMode: (state, action: PayloadAction<"normal" | "casual">) => {
       state.deathPenaltyMode = action.payload;
@@ -1114,6 +1203,13 @@ export const {
   purchaseAutoEatUnlock,
   setAutoEat,
   setAutoEatHpPercent,
+  acceptSectQuest,
+  incrementSectQuestKillCount,
+  claimSectQuestReward,
+  addNpcFavor,
+  useRealmDialogue,
+  setCultivationPartner,
+  giftNpc,
   setDeathPenaltyMode,
   setWeakened,
   tickWeakenedRecovery,

--- a/src/state/selectors/characterSelectors.ts
+++ b/src/state/selectors/characterSelectors.ts
@@ -13,6 +13,7 @@ import {
 } from "../../constants/skillSets";
 import { KARMA_BONUSES_BY_ID, type KarmaBonusId } from "../../constants/reincarnation";
 import { getTalentBonuses } from "../../constants/talents";
+import { getSectNpcById, getDualCultivationBonusPercent, type SectNpcI } from "../../constants/sectRelationships";
 
 /** Sum equipment bonuses for combat stats. Sword & ring → attack; helmet, body & amulet → defense and vitality; combatTechnique & ring → attack speed; amulet → qiGainBonus. */
 function getEquipmentCombatBonuses(equipment: RootState["character"]["equipment"]) {
@@ -323,4 +324,20 @@ export const getCraftingSetCookingXpPercent = createSelector(
 export const getTalentAlchemySuccessPercent = createSelector(
   [getTalentBonusesSelector],
   (talentBonuses) => talentBonuses.alchemySuccessPercent
+);
+
+/** Cultivation partner info for meditation (dual cultivation qi bonus). */
+export const getCultivationPartnerInfo = createSelector(
+  [
+    (state: RootState) => state.character.cultivationPartner,
+    (state: RootState) => state.character.npcFavor,
+  ],
+  (partner, npcFavor) => {
+    if (!partner) return { npc: undefined as SectNpcI | undefined, favor: 0, bonusPercent: 0 };
+    const npc = getSectNpcById(partner.npcId);
+    const key = `${partner.sectId}-${partner.npcId}`;
+    const favor = npcFavor[key] ?? 0;
+    const bonusPercent = getDualCultivationBonusPercent(favor);
+    return { npc, favor, bonusPercent };
+  }
 );

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -33,6 +33,12 @@ function migratePersistedState(state: unknown, _version: number): Promise<unknow
     if (c.autoEatUnlocked == null) c.autoEatUnlocked = false;
     if (c.autoEat == null) c.autoEat = false;
     if (c.autoEatHpPercent == null) c.autoEatHpPercent = 30;
+    if (c.sectQuestProgress == null) c.sectQuestProgress = {};
+    if (c.sectQuestKillCount == null) c.sectQuestKillCount = {};
+    if (c.obtainedSectTreasureIds == null) c.obtainedSectTreasureIds = [];
+    if (c.npcFavor == null) c.npcFavor = {};
+    if (c.realmDialogueUsed == null) c.realmDialogueUsed = {};
+    if (c.cultivationPartner == null) c.cultivationPartner = null;
   }
   return Promise.resolve(state);
 }


### PR DESCRIPTION
- Introduced new quest mechanics for sects, allowing players to accept and complete sect quests for unique treasures.
- Implemented NPC relationships, enabling players to gift spirit stones and engage in dual cultivation with romanceable NPCs.
- Updated character state management to track quest progress, NPC favor, and cultivation partners.
- Enhanced UI components for sect interactions, including a new tabbed interface for store, bulletin board, and relationships.
- Added CSS styles for improved layout and user experience in the SectContainer and MeditationContainer.
- Updated TODO.md to reflect new asset requirements for NPC images and sect treasures.